### PR TITLE
fix: 修复在食药装备页面修改等级报错的问题

### DIFF
--- a/src/components/Gearset.vue
+++ b/src/components/Gearset.vue
@@ -1,4 +1,4 @@
-<!-- 
+<!--
     This file is part of BestCraft.
     Copyright (C) 2025  Tnze
 
@@ -25,6 +25,7 @@ import {
     ElCheckboxGroup,
     ElCheckboxButton,
 } from 'element-plus';
+import { ref, watch } from 'vue';
 import { Jobs } from '@/libs/Craft';
 import useGearsets from '@/stores/gearsets';
 import { choiceGearsetDisplayName } from '@/libs/Gearsets';
@@ -33,7 +34,31 @@ const store = useGearsets();
 const props = defineProps<{
     index: number;
     simplify?: boolean;
+    minLevel?: number;
 }>();
+
+const emit = defineEmits<{
+    (e: 'levelChange', level: number): void;
+}>();
+
+const localLevel = ref(store.gearsets[props.index].value.level);
+
+// change localLevel
+watch(
+    () => store.gearsets[props.index].value.level,
+    newLevel => {
+        localLevel.value = newLevel;
+    },
+);
+
+// Only emit levelChange when the localLevel changes
+function handleLevelChange(value: number | undefined) {
+    if (value === undefined || value === null) {
+        localLevel.value = store.gearsets[props.index].value.level;
+        return;
+    }
+    emit('levelChange', value);
+}
 </script>
 
 <template>
@@ -64,11 +89,12 @@ const props = defineProps<{
         </template>
         <el-form-item :label="$t('level')">
             <el-input-number
-                v-model="store.gearsets[index].value.level"
-                :min="1"
+                v-model="localLevel"
+                :min="minLevel ?? 1"
                 :max="100"
                 :step-strictly="true"
                 :value-on-clear="0"
+                @change="handleLevelChange"
             />
         </el-form-item>
         <el-form-item :label="$t('craftsmanship')">

--- a/src/components/Gearset.vue
+++ b/src/components/Gearset.vue
@@ -51,12 +51,15 @@ watch(
     },
 );
 
-// Only emit levelChange when the localLevel changes
 function handleLevelChange(value: number | undefined) {
     if (value === undefined || value === null) {
         localLevel.value = store.gearsets[props.index].value.level;
         return;
     }
+
+    // write to store directly
+    store.gearsets[props.index].value.level = value;
+
     emit('levelChange', value);
 }
 </script>
@@ -90,7 +93,7 @@ function handleLevelChange(value: number | undefined) {
         <el-form-item :label="$t('level')">
             <el-input-number
                 v-model="localLevel"
-                :min="minLevel ?? 1"
+                :min="1"
                 :max="100"
                 :step-strictly="true"
                 :value-on-clear="0"

--- a/src/components/designer/Designer.vue
+++ b/src/components/designer/Designer.vue
@@ -1,4 +1,4 @@
-<!-- 
+<!--
     This file is part of BestCraft.
     Copyright (C) 2026  Tnze
 
@@ -200,15 +200,33 @@ const initStatus = ref<Status>({
     )),
     quality: initQuality.value,
 });
+
+const minGearsetLevel = computed(() => {
+    const recipeLevel = props.recipe.job_level;
+    return Math.max(1, recipeLevel - 5);
+});
+
 watch([props, enhancedAttributes, initQuality], async ([p, ea, iq]) => {
-    initStatus.value = {
-        ...(await newStatus(
-            ea,
-            p.recipe,
-            store.content?.stellarSteadyHandCount ?? 0,
-        )),
-        quality: iq,
-    };
+    try {
+        initStatus.value = {
+            ...(await newStatus(
+                ea,
+                p.recipe,
+                store.content?.stellarSteadyHandCount ?? 0,
+            )),
+            quality: iq,
+        };
+    } catch (error) {
+        if (String(error) === 'player-level-lower-than-recipe-requirement') {
+            const currentGearset = selectedGearsetRow.value;
+            if (currentGearset) {
+                const minLevel = minGearsetLevel.value;
+                currentGearset.value.level = minLevel;
+            }
+        } else {
+            throw error;
+        }
+    }
 });
 
 // Active Sequence
@@ -396,6 +414,7 @@ async function handleSolverResult(
                             />
                         </el-scrollbar>
                     </el-tab-pane>
+                    <!-- 食药&装备 -->
                     <el-tab-pane
                         :label="$t('attributes-enhance')"
                         name="attributes-enhance"
@@ -405,6 +424,7 @@ async function handleSolverResult(
                             <AttrEnhSelector
                                 v-model="attributesEnhancers"
                                 v-model:gearset-id="gearsetId"
+                                v-model:min-level="minGearsetLevel"
                                 :job="isCustomRecipe ? undefined : displayJob"
                                 :attributes="attributes"
                             />
@@ -623,7 +643,7 @@ save-file = Save file
 save-success = Saving successed
 save-fail = Saving failed: { $reason }
 open-file = Open file
-read-n-macros = Read { $n -> 
+read-n-macros = Read { $n ->
     [one] one macro
     *[other] { $n } macros
 }
@@ -633,7 +653,7 @@ edit = Edit
 delete = Delete
 
 and = { $a } and { $b }
-attributes-do-not-meet-the-requirements = 
+attributes-do-not-meet-the-requirements =
     { $attribute }
     { $num ->
         [one] does

--- a/src/components/designer/Designer.vue
+++ b/src/components/designer/Designer.vue
@@ -59,6 +59,7 @@ import ActionQueue from './ActionQueue.vue';
 import StatusBar from './StatusBar.vue';
 import SolverList from './solvers/List.vue';
 import { useFluent } from 'fluent-vue';
+import { ElMessage } from 'element-plus';
 import Analyzers from './tabs/Analyzers.vue';
 import { activeSeqKey, displayJobKey } from './injectionkeys';
 import { Slot, Sequence, SequenceSource } from './types';
@@ -206,6 +207,24 @@ const minGearsetLevel = computed(() => {
     return Math.max(1, recipeLevel - 5);
 });
 
+// check job level
+watch(activeTab, newTab => {
+    if (newTab === 'attributes-enhance') {
+        const currentGearset = selectedGearsetRow.value;
+        if (currentGearset) {
+            const minLevel = minGearsetLevel.value;
+            if (currentGearset.value.level < minLevel) {
+                currentGearset.value.level = minLevel;
+                ElMessage({
+                    message: $t('level-adjusted-warning', { level: minLevel }),
+                    type: 'warning',
+                    duration: 3000,
+                });
+            }
+        }
+    }
+});
+
 watch([props, enhancedAttributes, initQuality], async ([p, ea, iq]) => {
     try {
         initStatus.value = {
@@ -222,6 +241,11 @@ watch([props, enhancedAttributes, initQuality], async ([p, ea, iq]) => {
             if (currentGearset) {
                 const minLevel = minGearsetLevel.value;
                 currentGearset.value.level = minLevel;
+                ElMessage({
+                    message: $t('level-adjusted-warning', { level: minLevel }),
+                    type: 'warning',
+                    duration: 3000,
+                });
             }
         } else {
             throw error;
@@ -596,6 +620,7 @@ delete = 删除
 and = { $a }和{ $b }
 attributes-do-not-meet-the-requirements = 装备{ $attribute }不满足配方要求
 attributes-requirements = 制作该配方要求：作业精度 ≥ { $craftsmanship } 且 加工精度 ≥ { $control }
+level-adjusted-warning = 等级不足，已自动调整为最低要求等级: { $level }
 </fluent>
 
 <fluent locale="zh-TW">
@@ -624,6 +649,7 @@ delete = 刪除
 and = { $a }和{ $b }
 attributes-do-not-meet-the-requirements = 裝備{ $attribute }不滿足配方要求
 attributes-requirements = 製作該配方要求：作業精度 ≥ { $craftsmanship } 且 加工精度 ≥ { $control }
+level-adjusted-warning = 等級不足，已自動調整為最低要求等級: { $level }
 </fluent>
 
 <fluent locale="en-US">
@@ -661,6 +687,7 @@ attributes-do-not-meet-the-requirements =
     }
     not meet the requirements.
 attributes-requirements = Require: craftsmanship ≥ { $craftsmanship } and control ≥ { $control }
+level-adjusted-warning = Level insufficient, automatically adjusted to minimum required level: { $level }
 </fluent>
 
 <fluent locale="ja-JP">
@@ -669,4 +696,5 @@ init-quality = 初期品質
 and = { $a }と{ $b }
 attributes-do-not-meet-the-requirements = { $attribute }が足りないため
 attributes-requirements = 製作可能条件：{ craftsmanship }{ $craftsmanship}以上 と { control }{ $control }以上
+level-adjusted-warning = レベルが不足しているため、最低要求レベルに自動調整されました: { $level }
 </fluent>

--- a/src/components/designer/tabs/AttrEnhSelector.vue
+++ b/src/components/designer/tabs/AttrEnhSelector.vue
@@ -1,4 +1,4 @@
-<!-- 
+<!--
     This file is part of BestCraft.
     Copyright (C) 2025  Tnze
 
@@ -75,9 +75,18 @@ const selectedGearsetIndex = computed(() =>
     gearsets.gearsets.findIndex(v => v.id == selectedGearset.value),
 );
 
+const minLevel = defineModel<number | undefined>('minLevel');
+
 const emits = defineEmits<{
     (event: 'update:modelValue', v: Enhancer[]): void;
 }>();
+
+function handleLevelChange(level: number) {
+    const index = selectedGearsetIndex.value;
+    if (index === -1) return;
+
+    gearsets.gearsets[index].value.level = level;
+}
 
 onMounted(async () => loadMealsAndMedicine(setting.getDataSource()));
 watch(() => setting.getDataSource(), loadMealsAndMedicine);
@@ -235,7 +244,9 @@ function EnhIncComponent(props: {
             <Gearset
                 v-if="selectedGearsetIndex != -1"
                 :index="selectedGearsetIndex"
+                :min-level="minLevel"
                 simplify
+                @level-change="handleLevelChange"
             />
         </template>
     </el-form>


### PR DESCRIPTION
1. 修改了组件监听逻辑，现在食药装备选项卡中修改等级只有在失焦、回车或者点按钮的情况下生效，避免了输入到一半就校验出错的情况
2. 添加配方最低等级限制，低于配方等级会弹窗同时强制调整为最低等级（在配装页面也生效）
3. （优化）在选择配方界面，对于宇宙探索的等级同步配方，可以自动填入当前套装的等级
4.  为了实现3，增加了对数据库中Craft Type的翻译

<img width="1313" height="878" alt="image" src="https://github.com/user-attachments/assets/21611f44-974d-4250-a4a1-361e96881bcc" />

<img width="1111" height="768" alt="image" src="https://github.com/user-attachments/assets/ebe274c3-35b7-485b-a7ca-d8ac48c9be6c" />
