### PR TITLE
feat: 自动填写等级同步配方的等级

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ target
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ target
 !.yarn/versions
 
 .env
+config.toml

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,2 @@
+[lang.zh-CN]
+database = 'sqlite://src-tauri/assets/xiv.db?mode=ro'

--- a/config.toml
+++ b/config.toml
@@ -1,2 +1,0 @@
-[lang.zh-CN]
-database = 'sqlite://src-tauri/assets/xiv.db?mode=ro'

--- a/src-server/src/main.rs
+++ b/src-server/src/main.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::{
-    collections::{BTreeMap, HashMap}, env, u64::MAX,
+    collections::{BTreeMap, HashMap}, env,
 };
 
 use salvo::cors;
@@ -114,6 +114,7 @@ struct RecipeInfo {
     item_id: u32,
     item_name: String,
     item_amount: u8,
+    craft_type_id: u32,
     job: String,
 
     difficulty_factor: u16,
@@ -264,6 +265,7 @@ async fn recipe_table(req: &mut Request, depot: &mut Depot, res: &mut Response) 
         .column_as(items::Column::Id, "item_id")
         .column_as(items::Column::Name, "item_name")
         .column_as(recipes::Column::ItemResultAmount, "item_amount")
+        .column_as(recipes::Column::CraftTypeId, "craft_type_id")
         .column_as(craft_types::Column::Name, "job")
         .column_as(recipes::Column::DifficultyFactor, "difficulty_factor")
         .column_as(recipes::Column::QualityFactor, "quality_factor")
@@ -418,6 +420,7 @@ async fn recipe_info(req: &mut Request, depot: &mut Depot, res: &mut Response) -
         .column_as(items::Column::Id, "item_id")
         .column_as(items::Column::Name, "item_name")
         .column_as(recipes::Column::ItemResultAmount, "item_amount")
+        .column_as(recipes::Column::CraftTypeId, "craft_type_id")
         .column_as(craft_types::Column::Name, "job")
         .column_as(recipes::Column::DifficultyFactor, "difficulty_factor")
         .column_as(recipes::Column::QualityFactor, "quality_factor")

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -124,6 +124,7 @@ struct RecipeInfo {
     item_id: i32,
     item_name: String,
     item_amount: i32,
+    craft_type_id: u32,
     job: String,
 
     difficulty_factor: u16,
@@ -203,6 +204,7 @@ async fn recipe_table(
         .column_as(items::Column::Id, "item_id")
         .column_as(items::Column::Name, "item_name")
         .column_as(recipes::Column::ItemResultAmount, "item_amount")
+        .column_as(recipes::Column::CraftTypeId, "craft_type_id")
         .column_as(craft_types::Column::Name, "job")
         .column_as(recipes::Column::DifficultyFactor, "difficulty_factor")
         .column_as(recipes::Column::QualityFactor, "quality_factor")
@@ -247,6 +249,7 @@ async fn search_recipe_by_ids(
         .column_as(items::Column::Id, "item_id")
         .column_as(items::Column::Name, "item_name")
         .column_as(recipes::Column::ItemResultAmount, "item_amount")
+        .column_as(recipes::Column::CraftTypeId, "craft_type_id")
         .column_as(craft_types::Column::Name, "job")
         .column_as(recipes::Column::DifficultyFactor, "difficulty_factor")
         .column_as(recipes::Column::QualityFactor, "quality_factor")

--- a/src/components/recipe-manager/ConfirmDialog.vue
+++ b/src/components/recipe-manager/ConfirmDialog.vue
@@ -1,4 +1,4 @@
-<!-- 
+<!--
     This file is part of BestCraft.
     Copyright (C) 2026  Tnze
 
@@ -30,15 +30,17 @@ import {
     CollectablesShopRefine,
     Conditions,
     Item,
+    Jobs,
     newRecipe,
     Recipe,
     RecipeInfo,
 } from '@/libs/Craft';
-import { selectRecipe } from './common';
+import { recipeInfoToJob, selectRecipe } from './common';
 import { useMediaQuery } from '@vueuse/core';
 import { useRouter } from 'vue-router';
 import { computed, onWatcherCleanup, ref, watch } from 'vue';
 import useSettingStore from '@/stores/settings';
+import useGearsetsStore from '@/stores/gearsets';
 import { useFluent } from 'fluent-vue';
 import Condition from '../designer/Condition.vue';
 
@@ -51,6 +53,7 @@ const props = defineProps<{
 const router = useRouter();
 const { $t } = useFluent();
 const settingsStore = useSettingStore();
+const gearsetsStore = useGearsetsStore();
 const visible = defineModel<boolean>({ required: true });
 const rawRecipe = defineModel<Recipe>('recipe', { required: true });
 const compactLayout = useMediaQuery('screen and (max-width: 500px)');
@@ -69,6 +72,28 @@ const recipe = computed(() =>
     isDynRecipe.value && dynRecipe.value != undefined
         ? dynRecipe.value
         : rawRecipe.value,
+);
+const currentJob = computed<Jobs | undefined>(() =>
+    recipeInfoToJob(props.recipeInfo.craft_type_id, props.recipeInfo.job),
+);
+const currentJobGearsetLevel = computed<number>(() => {
+    const job = currentJob.value;
+    if (job == undefined) return gearsetsStore.default.value.level;
+
+    const gearset = gearsetsStore.gearsets.find(
+        (v, i) => i != 0 && v.compatibleJobs.includes(job),
+    );
+    return (gearset ?? gearsetsStore.default).value.level;
+});
+
+watch(
+    [visible, isDynRecipe, () => props.recipeInfo.id],
+    ([visible, isDynRecipe]) => {
+        if (visible && isDynRecipe) {
+            dynRecipeLevel.value = currentJobGearsetLevel.value;
+        }
+    },
+    { immediate: true },
 );
 
 async function loadDynRecipe(
@@ -131,6 +156,7 @@ async function confirm(mode: 'simulator' | 'designer') {
         props.collectability,
         itemInfo,
         props.recipeInfo.job,
+        props.recipeInfo.craft_type_id,
         mode == 'simulator',
         props.stellarSteadyHandCount,
     );

--- a/src/components/recipe-manager/ConfirmDialog.vue
+++ b/src/components/recipe-manager/ConfirmDialog.vue
@@ -1,6 +1,6 @@
 <!--
     This file is part of BestCraft.
-    Copyright (C) 2026  Tnze
+    Copyright (C) 2026  Tnze & ThermosBottle
 
     BestCraft is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -74,7 +74,7 @@ const recipe = computed(() =>
         : rawRecipe.value,
 );
 const currentJob = computed<Jobs | undefined>(() =>
-    recipeInfoToJob(props.recipeInfo.craft_type_id, props.recipeInfo.job),
+    recipeInfoToJob(props.recipeInfo.craft_type_id),
 );
 const currentJobGearsetLevel = computed<number>(() => {
     const job = currentJob.value;
@@ -155,7 +155,6 @@ async function confirm(mode: 'simulator' | 'designer') {
         props.recipeInfo,
         props.collectability,
         itemInfo,
-        props.recipeInfo.job,
         props.recipeInfo.craft_type_id,
         mode == 'simulator',
         props.stellarSteadyHandCount,

--- a/src/components/recipe-manager/ConfirmDialog.vue
+++ b/src/components/recipe-manager/ConfirmDialog.vue
@@ -35,7 +35,7 @@ import {
     Recipe,
     RecipeInfo,
 } from '@/libs/Craft';
-import { recipeInfoToJob, selectRecipe } from './common';
+import { craftTypeIdToJob, selectRecipe } from './common';
 import { useMediaQuery } from '@vueuse/core';
 import { useRouter } from 'vue-router';
 import { computed, onWatcherCleanup, ref, watch } from 'vue';
@@ -74,7 +74,7 @@ const recipe = computed(() =>
         : rawRecipe.value,
 );
 const currentJob = computed<Jobs | undefined>(() =>
-    recipeInfoToJob(props.recipeInfo.craft_type_id),
+    craftTypeIdToJob(props.recipeInfo.craft_type_id),
 );
 const currentJobGearsetLevel = computed<number>(() => {
     const job = currentJob.value;

--- a/src/components/recipe-manager/CustomizeRecipe.vue
+++ b/src/components/recipe-manager/CustomizeRecipe.vue
@@ -1,4 +1,4 @@
-<!-- 
+<!--
     This file is part of BestCraft.
     Copyright (C) 2026  Tnze
 
@@ -130,15 +130,16 @@ function confirm(simulatorMode: boolean) {
         required_control: 0,
     };
     selectRecipe(
-        customRecipe.value,
-        undefined,
-        0,
-        requirements,
-        undefined,
-        itemInfo,
-        '',
-        simulatorMode,
-        3,
+        customRecipe.value, // recipe
+        undefined, // recipeId
+        0, // materialQualityFactor
+        requirements, // requirements
+        undefined, // collectability
+        itemInfo, // item
+        undefined, // craftType
+        undefined, // craftTypeId
+        simulatorMode, // simulatorMode
+        3, // stellarSteadyHandCount
     );
     router.push({ name: 'designer' });
 }

--- a/src/components/recipe-manager/CustomizeRecipe.vue
+++ b/src/components/recipe-manager/CustomizeRecipe.vue
@@ -136,7 +136,6 @@ function confirm(simulatorMode: boolean) {
         requirements, // requirements
         undefined, // collectability
         itemInfo, // item
-        undefined, // craftType
         undefined, // craftTypeId
         simulatorMode, // simulatorMode
         3, // stellarSteadyHandCount

--- a/src/components/recipe-manager/common.ts
+++ b/src/components/recipe-manager/common.ts
@@ -25,7 +25,22 @@ import useDesignerStore from '@/stores/designer';
 
 const designerStore = useDesignerStore();
 
-const jobMapsZhCN: { [key: string]: Jobs } = {
+export const craftTypeIdToJobMap: Record<number, Jobs> = {
+    0: Jobs.Carpenter,
+    1: Jobs.Blacksmith,
+    2: Jobs.Armorer,
+    3: Jobs.Goldsmith,
+    4: Jobs.Leatherworker,
+    5: Jobs.Weaver,
+    6: Jobs.Alchemist,
+    7: Jobs.Culinarian,
+};
+
+// Fallback for online API responses that don't provide
+// `craft_type_id` now. So we have to use `craftTypeIdToJob` /
+// `recipeInfoToJob(craft_type_id, ...)` and treat names as display data only.
+const legacyCraftTypeNameToJobMap: Record<string, Jobs> = {
+    // zh-CN
     木工: Jobs.Carpenter,
     锻冶: Jobs.Blacksmith,
     铸甲: Jobs.Armorer,
@@ -34,18 +49,24 @@ const jobMapsZhCN: { [key: string]: Jobs } = {
     裁缝: Jobs.Weaver,
     炼金: Jobs.Alchemist,
     烹调: Jobs.Culinarian,
-};
-const jobMapsZhTW: { [key: string]: Jobs } = {
-    木工: Jobs.Carpenter,
+
+    // zh-TW
     鍛造: Jobs.Blacksmith,
-    甲冑: Jobs.Armorer,
     金工: Jobs.Goldsmith,
     皮革: Jobs.Leatherworker,
     裁縫: Jobs.Weaver,
     鍊金: Jobs.Alchemist,
     烹調: Jobs.Culinarian,
-};
-const jobMapsEn: { [key: string]: Jobs } = {
+
+    // ja-JP
+    鍛冶: Jobs.Blacksmith,
+    甲冑: Jobs.Armorer,
+    彫金: Jobs.Goldsmith,
+    革細工: Jobs.Leatherworker,
+    錬金: Jobs.Alchemist,
+    調理: Jobs.Culinarian,
+
+    // en-US
     Woodworking: Jobs.Carpenter,
     Smithing: Jobs.Blacksmith,
     Armorcraft: Jobs.Armorer,
@@ -54,18 +75,8 @@ const jobMapsEn: { [key: string]: Jobs } = {
     Clothcraft: Jobs.Weaver,
     Alchemy: Jobs.Alchemist,
     Cooking: Jobs.Culinarian,
-};
-const jobMapsJa: { [key: string]: Jobs } = {
-    木工: Jobs.Carpenter,
-    鍛冶: Jobs.Blacksmith,
-    甲冑: Jobs.Armorer,
-    彫金: Jobs.Goldsmith,
-    革細工: Jobs.Leatherworker,
-    裁縫: Jobs.Weaver,
-    錬金: Jobs.Alchemist,
-    調理: Jobs.Culinarian,
-};
-const jobMapsDe: { [key: string]: Jobs } = {
+
+    // de-DE
     Zimmerer: Jobs.Carpenter,
     Grobschmied: Jobs.Blacksmith,
     Plattner: Jobs.Armorer,
@@ -74,8 +85,8 @@ const jobMapsDe: { [key: string]: Jobs } = {
     Weber: Jobs.Weaver,
     Alchemist: Jobs.Alchemist,
     Gourmet: Jobs.Culinarian,
-};
-const jobMapsFr: { [key: string]: Jobs } = {
+
+    // fr-FR
     Menuiserie: Jobs.Carpenter,
     Métallurgie: Jobs.Blacksmith,
     Armurerie: Jobs.Armorer,
@@ -86,14 +97,20 @@ const jobMapsFr: { [key: string]: Jobs } = {
     Cuisine: Jobs.Culinarian,
 };
 
-export function craftTypeTojobs(craftType: string): Jobs | undefined {
+export function craftTypeIdToJob(
+    craftTypeId: number | undefined,
+): Jobs | undefined {
+    return craftTypeId == undefined
+        ? undefined
+        : craftTypeIdToJobMap[craftTypeId];
+}
+export function recipeInfoToJob(
+    craftTypeId: number | undefined,
+    craftTypeName: string | undefined,
+): Jobs | undefined {
     return (
-        jobMapsZhCN[craftType] ??
-        jobMapsZhTW[craftType] ??
-        jobMapsEn[craftType] ??
-        jobMapsJa[craftType] ??
-        jobMapsDe[craftType] ??
-        jobMapsFr[craftType]
+        craftTypeIdToJob(craftTypeId) ??
+        legacyCraftTypeNameToJobMap[craftTypeName ?? '']
     );
 }
 
@@ -104,12 +121,13 @@ export const selectRecipe = (
     requirements: RecipeRequirements,
     collectability: CollectablesShopRefine | undefined,
     item: Item,
-    craftType: string,
+    craftType: string | undefined,
+    craftTypeId: number | undefined,
     simulatorMode: boolean,
     stellarSteadyHandCount: number,
 ) => {
     designerStore.selectRecipe({
-        job: craftTypeTojobs(craftType),
+        job: recipeInfoToJob(craftTypeId, craftType),
         item,
         recipe,
         recipeId,

--- a/src/components/recipe-manager/common.ts
+++ b/src/components/recipe-manager/common.ts
@@ -36,67 +36,6 @@ export const craftTypeIdToJobMap: Record<number, Jobs> = {
     7: Jobs.Culinarian,
 };
 
-// Fallback for online API responses that don't provide
-// `craft_type_id` now. So we have to use `craftTypeIdToJob` /
-// `recipeInfoToJob(craft_type_id, ...)` and treat names as display data only.
-const legacyCraftTypeNameToJobMap: Record<string, Jobs> = {
-    // zh-CN
-    木工: Jobs.Carpenter,
-    锻冶: Jobs.Blacksmith,
-    铸甲: Jobs.Armorer,
-    雕金: Jobs.Goldsmith,
-    制革: Jobs.Leatherworker,
-    裁缝: Jobs.Weaver,
-    炼金: Jobs.Alchemist,
-    烹调: Jobs.Culinarian,
-
-    // zh-TW
-    鍛造: Jobs.Blacksmith,
-    金工: Jobs.Goldsmith,
-    皮革: Jobs.Leatherworker,
-    裁縫: Jobs.Weaver,
-    鍊金: Jobs.Alchemist,
-    烹調: Jobs.Culinarian,
-
-    // ja-JP
-    鍛冶: Jobs.Blacksmith,
-    甲冑: Jobs.Armorer,
-    彫金: Jobs.Goldsmith,
-    革細工: Jobs.Leatherworker,
-    錬金: Jobs.Alchemist,
-    調理: Jobs.Culinarian,
-
-    // en-US
-    Woodworking: Jobs.Carpenter,
-    Smithing: Jobs.Blacksmith,
-    Armorcraft: Jobs.Armorer,
-    Goldsmithing: Jobs.Goldsmith,
-    Leatherworking: Jobs.Leatherworker,
-    Clothcraft: Jobs.Weaver,
-    Alchemy: Jobs.Alchemist,
-    Cooking: Jobs.Culinarian,
-
-    // de-DE
-    Zimmerer: Jobs.Carpenter,
-    Grobschmied: Jobs.Blacksmith,
-    Plattner: Jobs.Armorer,
-    Goldschmied: Jobs.Goldsmith,
-    Gerber: Jobs.Leatherworker,
-    Weber: Jobs.Weaver,
-    Alchemist: Jobs.Alchemist,
-    Gourmet: Jobs.Culinarian,
-
-    // fr-FR
-    Menuiserie: Jobs.Carpenter,
-    Métallurgie: Jobs.Blacksmith,
-    Armurerie: Jobs.Armorer,
-    Orfèvrerie: Jobs.Goldsmith,
-    Tannerie: Jobs.Leatherworker,
-    Couture: Jobs.Weaver,
-    Alchimie: Jobs.Alchemist,
-    Cuisine: Jobs.Culinarian,
-};
-
 export function craftTypeIdToJob(
     craftTypeId: number | undefined,
 ): Jobs | undefined {
@@ -106,12 +45,8 @@ export function craftTypeIdToJob(
 }
 export function recipeInfoToJob(
     craftTypeId: number | undefined,
-    craftTypeName: string | undefined,
 ): Jobs | undefined {
-    return (
-        craftTypeIdToJob(craftTypeId) ??
-        legacyCraftTypeNameToJobMap[craftTypeName ?? '']
-    );
+    return craftTypeIdToJob(craftTypeId);
 }
 
 export const selectRecipe = (
@@ -121,13 +56,12 @@ export const selectRecipe = (
     requirements: RecipeRequirements,
     collectability: CollectablesShopRefine | undefined,
     item: Item,
-    craftType: string | undefined,
     craftTypeId: number | undefined,
     simulatorMode: boolean,
     stellarSteadyHandCount: number,
 ) => {
     designerStore.selectRecipe({
-        job: recipeInfoToJob(craftTypeId, craftType),
+        job: recipeInfoToJob(craftTypeId),
         item,
         recipe,
         recipeId,

--- a/src/components/recipe-manager/common.ts
+++ b/src/components/recipe-manager/common.ts
@@ -43,11 +43,6 @@ export function craftTypeIdToJob(
         ? undefined
         : craftTypeIdToJobMap[craftTypeId];
 }
-export function recipeInfoToJob(
-    craftTypeId: number | undefined,
-): Jobs | undefined {
-    return craftTypeIdToJob(craftTypeId);
-}
 
 export const selectRecipe = (
     recipe: Recipe,
@@ -61,7 +56,7 @@ export const selectRecipe = (
     stellarSteadyHandCount: number,
 ) => {
     designerStore.selectRecipe({
-        job: recipeInfoToJob(craftTypeId),
+        job: craftTypeIdToJob(craftTypeId),
         item,
         recipe,
         recipeId,

--- a/src/libs/Craft.ts
+++ b/src/libs/Craft.ts
@@ -404,8 +404,6 @@ export interface RecipeInfo {
     item_id: number;
     item_name: string;
     item_amount?: number;
-    // Legacy online API responses may omit this field. Local Tauri and the
-    // Rust server expose it directly from Recipes.CraftTypeId.
     craft_type_id?: number;
     job: string;
 

--- a/src/libs/Craft.ts
+++ b/src/libs/Craft.ts
@@ -404,6 +404,9 @@ export interface RecipeInfo {
     item_id: number;
     item_name: string;
     item_amount?: number;
+    // Legacy online API responses may omit this field. Local Tauri and the
+    // Rust server expose it directly from Recipes.CraftTypeId.
+    craft_type_id?: number;
     job: string;
 
     difficulty_factor: number;


### PR DESCRIPTION
思路：`recipe_info`直接使用数据库的`CraftTypeId`，前端都按照这个Id来显示类型
1. 目前远程数据源拿不到`CraftTypeId`字段，于是整理了`common.ts`原有的映射逻辑，一方面能用配方类型的字符串匹配，一方面也能用传入的`recipeInfo.craft_type_id`查表
```
const craftTypeIdToJobMap: Record<number, Jobs> = {
    0: Jobs.Carpenter,
    1: Jobs.Blacksmith,
    2: Jobs.Armorer,
    3: Jobs.Goldsmith,
    4: Jobs.Leatherworker,
    5: Jobs.Weaver,
    6: Jobs.Alchemist,
    7: Jobs.Culinarian,
};
```
2. 在`ConfirmDialog.vue`里监听显示事件，若为等级同步配方则根据当前配方的`craft_type`查`job`，从套装列表拿来当前职业等级；如果未找到相应套装则返回默认等级填入
3. 本地数据源测试没有问题，但是远程数据源还不行，只能填默认套装等级

<img width="1732" height="1140" alt="image" src="https://github.com/user-attachments/assets/43d849b8-5f30-4860-ad5c-792d6c68a641" />

